### PR TITLE
Adding Deployment Test/Beaker Scope

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,12 @@ node {
 
   def hostaddress = InetAddress.localHost.hostAddress
 
+  stage 'Deployment Test'
+  puppet.hiera scope: 'beaker', key: 'rgbank-build-version', value: version
+  puppet.hiera scope: 'beaker', key: 'rgbank-build-path', value: "http://" + hostaddress + "/builds/rgbank/rgbank-build-${version}.tar.gz"
+  puppet.hiera scope: 'beaker', key: 'rgbank-mock-sql-path', value: "http://" + hostaddress + "/builds/rgbank/rgbank.sql"
+  build job: 'puppetlabs-rgbank-spec', parameters: [string(name: 'COMMIT', value: env.rgbank_module_ver)]
+
   puppet.credentials 'pe-access-token'
 
   stage 'Deploy to dev'


### PR DESCRIPTION
Prior to this commit there was no test of both configuration and
application code before rolling to dev.  This commit adds an
integration test that will deploy the latest version of application
code along with the latest SQL import file using configuration code
(Puppet).  This is done via the Beaker acceptance testing harness,
using job `puppetlabs-rgbank-spec`.
